### PR TITLE
Change all client methods to use SlashauthResponse type

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased] - yyyy-mm-dd
+
+Here we write upgrading notes for brands. It's a team effort to make them as
+straightforward as possible.
+
+### Added
+
+- [PROJECTNAME-XXXX](http://tickets.projectname.com/browse/PROJECTNAME-XXXX)
+  MINOR Ticket title goes here.
+- [PROJECTNAME-YYYY](http://tickets.projectname.com/browse/PROJECTNAME-YYYY)
+  PATCH Ticket title goes here.
+
+### Changed
+
+### Fixed
+
+## [0.10.0] - 2022-12-14 (BREAKING CHANGES)
+
+### Added
+
+### Changed
+
+- BREAKING CHANGE: Method calls now return `SlashauthResponse` generic type. Example:
+
+```
+const [data, metadata, err] = await slashauthClient.[controller].[method]();
+```
+
+For more information, please checkout our docs.
+
+### Fixed

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/node-client",
-  "version": "0.8.0-beta3",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/node-client",
-      "version": "0.8.0-beta3",
+      "version": "0.10.0",
       "license": "ISC",
       "dependencies": {
         "@slashauth/types": "^0.1.0-beta2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/node-client",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,7 +28,7 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@slashauth/types": "^0.3.1",
+    "@slashauth/types": "^0.4.0",
     "axios": "^1.2.0",
     "crypto": "^1.0.1",
     "typed-rest-client": "^1.8.9"

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -5,6 +5,53 @@ import { UserController } from './controllers/user';
 import { FileController } from './controllers/file';
 import { AppController } from './controllers/app';
 
+type ResponseMeta<T> = Omit<rm.IRestResponse<T>, 'result'>;
+type ErrorMessage = any;
+
+export type SlashauthResponse<ResponseData> = [
+  ResponseData | null,
+  ResponseMeta<ResponseData>,
+  ErrorMessage | null
+];
+
+type TypeOfClassMethod<T, M extends keyof T> = T[M] extends Function
+  ? T[M]
+  : never;
+
+const wrapMethod =
+  <M>(fn: (...args: any[]) => Promise<rm.IRestResponse<any>>) =>
+  <T>(...args: any[]): Promise<SlashauthResponse<T>> =>
+    fn(...args).then(
+      (res) => [
+        res.result,
+        { headers: res.headers, statusCode: res.statusCode },
+        null,
+      ],
+      (err) => [
+        null,
+        { headers: err['responseHeaders'], statusCode: err['statusCode'] },
+        err.message,
+      ]
+    );
+
+export interface WrappedClient {
+  get<T>(
+    ...args: Parameters<TypeOfClassMethod<rm.RestClient, 'get'>>
+  ): Promise<SlashauthResponse<T>>;
+  create<T>(
+    ...args: Parameters<TypeOfClassMethod<rm.RestClient, 'create'>>
+  ): Promise<SlashauthResponse<T>>;
+  replace<T>(
+    ...args: Parameters<TypeOfClassMethod<rm.RestClient, 'replace'>>
+  ): Promise<SlashauthResponse<T>>;
+  del<T>(
+    ...args: Parameters<TypeOfClassMethod<rm.RestClient, 'del'>>
+  ): Promise<SlashauthResponse<T>>;
+  update<T>(
+    ...args: Parameters<TypeOfClassMethod<rm.RestClient, 'update'>>
+  ): Promise<SlashauthResponse<T>>;
+}
+
 export class SlashauthClient {
   // Controllers
   app: AppController;
@@ -18,10 +65,18 @@ export class SlashauthClient {
     additional: Partial<Config>
   ) {
     const identifier = `node-rest-client_${additional.version || '1.0.0'}`;
-    const apiClient = new rm.RestClient(
+    const rawApiClient = new rm.RestClient(
       identifier,
       additional.endpoint || PROD_ENDPOINT
     );
+
+    const apiClient = {
+      get: wrapMethod(rawApiClient.get),
+      create: wrapMethod(rawApiClient.create),
+      replace: wrapMethod(rawApiClient.replace),
+      del: wrapMethod(rawApiClient.del),
+      update: wrapMethod(rawApiClient.update),
+    } as WrappedClient;
 
     this.app = new AppController(client_id, client_secret, apiClient);
     this.user = new UserController(client_id, client_secret, apiClient);

--- a/packages/core/src/controllers/app.ts
+++ b/packages/core/src/controllers/app.ts
@@ -2,11 +2,18 @@ import {
   GetInfoResponse,
   GetRoleRestrictedDataArguments,
   RoleRestrictedDataAPIResponse,
+  RoleRestrictedData,
   UpdateRoleRestrictedDataArguments,
+  App,
 } from '@slashauth/types';
 import { WrappedClient, SlashauthResponse } from '../client';
 import { signQuery, signBody } from '../utils/query';
 import { Controller } from './controller';
+
+const transformResponse =
+  <I, O>(responseMapper: (data: I | null) => SlashauthResponse<O>['0']) =>
+  ([data, ...res]: SlashauthResponse<I>): SlashauthResponse<O> =>
+    [responseMapper(data), ...res];
 
 export class AppController extends Controller {
   constructor(
@@ -17,14 +24,16 @@ export class AppController extends Controller {
     super(client_id, client_secret, apiClient);
   }
 
-  async getInfo(): Promise<SlashauthResponse<GetInfoResponse>> {
-    return this.apiClient.get<GetInfoResponse>(`/s/${this.client_id}`);
+  async getInfo(): Promise<SlashauthResponse<App>> {
+    return this.apiClient
+      .get<GetInfoResponse>(`/s/${this.client_id}`)
+      .then(transformResponse<GetInfoResponse, App>((res) => res && res.data));
   }
 
   async getRoleRestrictedData({
     role,
   }: GetRoleRestrictedDataArguments): Promise<
-    SlashauthResponse<RoleRestrictedDataAPIResponse>
+    SlashauthResponse<RoleRestrictedData>
   > {
     const encodedRole = Buffer.from(role, 'utf8').toString('base64');
 
@@ -36,21 +45,23 @@ export class AppController extends Controller {
       secret: this.client_secret,
     });
 
-    return this.apiClient.get<RoleRestrictedDataAPIResponse>(
-      `/s/${this.client_id}/role_metadata`,
-      {
-        queryParameters: {
-          params: urlParams,
-        },
-      }
-    );
+    return this.apiClient
+      .get<RoleRestrictedDataAPIResponse>(
+        `/s/${this.client_id}/role_metadata`,
+        {
+          queryParameters: {
+            params: urlParams,
+          },
+        }
+      )
+      .then(transformResponse((res) => res && res.data));
   }
 
   async updateRoleRestrictedData({
     role,
     metadata,
   }: UpdateRoleRestrictedDataArguments): Promise<
-    SlashauthResponse<RoleRestrictedDataAPIResponse>
+    SlashauthResponse<RoleRestrictedData>
   > {
     const body = signBody({
       input: {
@@ -60,9 +71,11 @@ export class AppController extends Controller {
       secret: this.client_secret,
     });
 
-    return await this.apiClient.replace<RoleRestrictedDataAPIResponse>(
-      `/s/${this.client_id}/role_metadata`,
-      body
-    );
+    return await this.apiClient
+      .replace<RoleRestrictedDataAPIResponse>(
+        `/s/${this.client_id}/role_metadata`,
+        body
+      )
+      .then(transformResponse((res) => res && res.data));
   }
 }

--- a/packages/core/src/controllers/app.ts
+++ b/packages/core/src/controllers/app.ts
@@ -4,7 +4,7 @@ import {
   RoleRestrictedDataAPIResponse,
   UpdateRoleRestrictedDataArguments,
 } from '@slashauth/types';
-import * as rm from 'typed-rest-client';
+import { WrappedClient, SlashauthResponse } from '../client';
 import { signQuery, signBody } from '../utils/query';
 import { Controller } from './controller';
 
@@ -12,19 +12,19 @@ export class AppController extends Controller {
   constructor(
     client_id: string,
     client_secret: string,
-    apiClient: rm.RestClient
+    apiClient: WrappedClient
   ) {
     super(client_id, client_secret, apiClient);
   }
 
-  async getInfo(): Promise<rm.IRestResponse<GetInfoResponse>> {
+  async getInfo(): Promise<SlashauthResponse<GetInfoResponse>> {
     return this.apiClient.get<GetInfoResponse>(`/s/${this.client_id}`);
   }
 
   async getRoleRestrictedData({
     role,
   }: GetRoleRestrictedDataArguments): Promise<
-    rm.IRestResponse<RoleRestrictedDataAPIResponse>
+    SlashauthResponse<RoleRestrictedDataAPIResponse>
   > {
     const encodedRole = Buffer.from(role, 'utf8').toString('base64');
 
@@ -50,7 +50,7 @@ export class AppController extends Controller {
     role,
     metadata,
   }: UpdateRoleRestrictedDataArguments): Promise<
-    rm.IRestResponse<RoleRestrictedDataAPIResponse>
+    SlashauthResponse<RoleRestrictedDataAPIResponse>
   > {
     const body = signBody({
       input: {

--- a/packages/core/src/controllers/controller.ts
+++ b/packages/core/src/controllers/controller.ts
@@ -1,14 +1,14 @@
-import * as rm from 'typed-rest-client';
+import { WrappedClient } from '../client';
 
 export class Controller {
   protected client_id: string;
   protected client_secret: string;
-  protected apiClient: rm.RestClient;
+  protected apiClient: WrappedClient;
 
   constructor(
     client_id: string,
     client_secret: string,
-    apiClient: rm.RestClient
+    apiClient: WrappedClient
   ) {
     this.client_id = client_id;
     this.client_secret = client_secret;

--- a/packages/core/src/controllers/file.ts
+++ b/packages/core/src/controllers/file.ts
@@ -1,8 +1,10 @@
 import {
+  FileRecord,
   GetFileByIDArguments,
   CRUDFileResponse,
   GetPresignedURLForFileArguments,
   GetPresignedURLForFileResponse,
+  PresignedURLForFile,
   ListFilesArguments,
   ListFilesResponse,
   CreateFileArguments,
@@ -10,8 +12,10 @@ import {
   DeleteFileArguments,
   CreateBlobUploadArguments,
   CreateBlobUploadResponse,
+  CreatedBlobData,
   UpdateBlobUploadStatusArguments,
   UpdateBlobUploadStatusResponse,
+  UpdatedBlobData,
   AddFileArguments,
   BlobStatus,
 } from '@slashauth/types';
@@ -22,6 +26,11 @@ import { checkBlobStatus } from '../utils/strings';
 import { getBaseURL } from '../utils/url';
 
 import { Controller } from './controller';
+
+const transformResponse =
+  <I, O>(responseMapper: (data: I | null) => SlashauthResponse<O>['0']) =>
+  ([data, ...res]: SlashauthResponse<I>): SlashauthResponse<O> =>
+    [responseMapper(data), ...res];
 
 export class FileController extends Controller {
   constructor(
@@ -35,7 +44,7 @@ export class FileController extends Controller {
   async getFileByID({
     id,
     organizationID,
-  }: GetFileByIDArguments): Promise<SlashauthResponse<CRUDFileResponse>> {
+  }: GetFileByIDArguments): Promise<SlashauthResponse<FileRecord>> {
     const input: { [key: string]: string } = {};
 
     if (organizationID) {
@@ -49,18 +58,24 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/files/${id}`;
 
-    return this.apiClient.get<CRUDFileResponse>(url, {
-      queryParameters: {
-        params: urlParams,
-      },
-    });
+    return this.apiClient
+      .get<CRUDFileResponse>(url, {
+        queryParameters: {
+          params: urlParams,
+        },
+      })
+      .then(
+        transformResponse<CRUDFileResponse, FileRecord>(
+          (res) => res && res.data
+        )
+      );
   }
 
   async getPresignedURL({
     id,
     organizationID,
   }: GetPresignedURLForFileArguments): Promise<
-    SlashauthResponse<GetPresignedURLForFileResponse>
+    SlashauthResponse<PresignedURLForFile>
   > {
     const input: { [key: string]: string } = {};
 
@@ -75,17 +90,21 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/files/${id}/url`;
 
-    return this.apiClient.get<GetPresignedURLForFileResponse>(url, {
-      queryParameters: {
-        params: urlParams,
-      },
-    });
+    return this.apiClient
+      .get<GetPresignedURLForFileResponse>(url, {
+        queryParameters: { params: urlParams },
+      })
+      .then(
+        transformResponse<GetPresignedURLForFileResponse, PresignedURLForFile>(
+          (res) => res && res.data.url
+        )
+      );
   }
 
   async listFiles({
     organizationID,
     cursor,
-  }: ListFilesArguments): Promise<SlashauthResponse<ListFilesResponse>> {
+  }: ListFilesArguments): Promise<SlashauthResponse<FileRecord[]>> {
     const input: { [key: string]: string } = {};
 
     if (organizationID) {
@@ -102,11 +121,19 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/files`;
 
-    return this.apiClient.get<ListFilesResponse>(url, {
-      queryParameters: {
-        params: urlParams,
-      },
-    });
+    return this.apiClient
+      .get<ListFilesResponse>(url, { queryParameters: { params: urlParams } })
+      .then((response) => {
+        const [data, metadata, err] = response;
+
+        return [
+          transformResponse<ListFilesResponse, FileRecord[]>(
+            (res) => res && res.data
+          )(response)[0],
+          { ...metadata, hasMore: data?.hasMore, cursor: data?.cursor },
+          err,
+        ];
+      });
   }
 
   async addFile({
@@ -117,7 +144,7 @@ export class FileController extends Controller {
     rolesRequired,
     mimeType,
     file,
-  }: AddFileArguments): Promise<SlashauthResponse<CRUDFileResponse>> {
+  }: AddFileArguments): Promise<SlashauthResponse<FileRecord>> {
     const [blobUpload] = await this.createBlobUpload({
       organizationID,
       wallet: userID,
@@ -129,7 +156,7 @@ export class FileController extends Controller {
       throw new Error('Failed to upload file');
     }
 
-    const { signedUrl: uploadURL, id } = blobUpload.data;
+    const { signedUrl: uploadURL, id } = blobUpload;
 
     await axios({
       method: 'PUT',
@@ -162,7 +189,7 @@ export class FileController extends Controller {
     name,
     description,
     rolesRequired,
-  }: UpdateFileArguments): Promise<SlashauthResponse<CRUDFileResponse>> {
+  }: UpdateFileArguments): Promise<SlashauthResponse<FileRecord>> {
     const body = signBody({
       input: {
         name,
@@ -174,13 +201,19 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/files/${id}`;
 
-    return await this.apiClient.update<CRUDFileResponse>(url, body);
+    return await this.apiClient
+      .update<CRUDFileResponse>(url, body)
+      .then(
+        transformResponse<CRUDFileResponse, FileRecord>(
+          (res) => res && res.data
+        )
+      );
   }
 
   async deleteFile({
     id,
     organizationID,
-  }: DeleteFileArguments): Promise<SlashauthResponse<CRUDFileResponse>> {
+  }: DeleteFileArguments): Promise<SlashauthResponse<FileRecord>> {
     const urlParams = signQuery({
       input: {}, // TODO: Does this need to exist?
       secret: this.client_secret,
@@ -188,11 +221,17 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/files/${id}`;
 
-    return await this.apiClient.del<CRUDFileResponse>(url, {
-      queryParameters: {
-        params: urlParams,
-      },
-    });
+    return await this.apiClient
+      .del<CRUDFileResponse>(url, {
+        queryParameters: {
+          params: urlParams,
+        },
+      })
+      .then(
+        transformResponse<CRUDFileResponse, FileRecord>(
+          (res) => res && res.data
+        )
+      );
   }
 
   private async createFile({
@@ -202,7 +241,7 @@ export class FileController extends Controller {
     name,
     description,
     rolesRequired,
-  }: CreateFileArguments): Promise<SlashauthResponse<CRUDFileResponse>> {
+  }: CreateFileArguments): Promise<SlashauthResponse<FileRecord>> {
     const body = signBody({
       input: {
         blobID,
@@ -216,7 +255,13 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/files`;
 
-    return await this.apiClient.create<CRUDFileResponse>(url, body);
+    return await this.apiClient
+      .create<CRUDFileResponse>(url, body)
+      .then(
+        transformResponse<CRUDFileResponse, FileRecord>(
+          (res) => res && res.data
+        )
+      );
   }
 
   // BLOBS
@@ -225,9 +270,7 @@ export class FileController extends Controller {
     wallet,
     mimeType,
     fileSize,
-  }: CreateBlobUploadArguments): Promise<
-    SlashauthResponse<CreateBlobUploadResponse>
-  > {
+  }: CreateBlobUploadArguments): Promise<SlashauthResponse<CreatedBlobData>> {
     const body = signBody({
       input: {
         wallet,
@@ -239,7 +282,13 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/blobs`;
 
-    return await this.apiClient.create<CreateBlobUploadResponse>(url, body);
+    return await this.apiClient
+      .create<CreateBlobUploadResponse>(url, body)
+      .then(
+        transformResponse<CreateBlobUploadResponse, CreatedBlobData>(
+          (res) => res && res.data
+        )
+      );
   }
 
   private async updateBlobUploadStatus({
@@ -247,7 +296,7 @@ export class FileController extends Controller {
     organizationID,
     status,
   }: UpdateBlobUploadStatusArguments): Promise<
-    SlashauthResponse<UpdateBlobUploadStatusResponse>
+    SlashauthResponse<UpdatedBlobData>
   > {
     const statusString = checkBlobStatus(status);
     const body = signBody({
@@ -259,9 +308,12 @@ export class FileController extends Controller {
 
     const url = `${getBaseURL(this.client_id, organizationID)}/blobs/${id}`;
 
-    return await this.apiClient.update<UpdateBlobUploadStatusResponse>(
-      url,
-      body
-    );
+    return await this.apiClient
+      .update<UpdateBlobUploadStatusResponse>(url, body)
+      .then(
+        transformResponse<UpdateBlobUploadStatusResponse, UpdatedBlobData>(
+          (res) => res && res.data
+        )
+      );
   }
 }

--- a/packages/core/src/controllers/organization.ts
+++ b/packages/core/src/controllers/organization.ts
@@ -1,4 +1,3 @@
-import * as rm from 'typed-rest-client';
 import {
   AddRoleRequirementOrganizationArguments,
   PostOrganizationArguments,
@@ -7,6 +6,7 @@ import {
   RoleRequirementAPIResponse,
   UpsertOrganizationAPIResponse,
 } from '@slashauth/types';
+import { WrappedClient, SlashauthResponse } from '../client';
 import { signBody, signQuery } from '../utils/query';
 import { Controller } from './controller';
 
@@ -14,7 +14,7 @@ export class OrganizationController extends Controller {
   constructor(
     client_id: string,
     client_secret: string,
-    apiClient: rm.RestClient
+    apiClient: WrappedClient
   ) {
     super(client_id, client_secret, apiClient);
   }
@@ -23,7 +23,7 @@ export class OrganizationController extends Controller {
     name,
     description,
   }: PostOrganizationArguments): Promise<
-    rm.IRestResponse<UpsertOrganizationAPIResponse>
+    SlashauthResponse<UpsertOrganizationAPIResponse>
   > {
     const body = signBody({
       input: {
@@ -44,7 +44,7 @@ export class OrganizationController extends Controller {
     name,
     description,
   }: PutOrganizationArguments): Promise<
-    rm.IRestResponse<UpsertOrganizationAPIResponse>
+    SlashauthResponse<UpsertOrganizationAPIResponse>
   > {
     const body = signBody({
       input: {
@@ -69,7 +69,7 @@ export class OrganizationController extends Controller {
     tokenTypeID,
     role,
   }: AddRoleRequirementOrganizationArguments): Promise<
-    rm.IRestResponse<RoleRequirementAPIResponse>
+    SlashauthResponse<RoleRequirementAPIResponse>
   > {
     const body = signBody({
       input: {
@@ -93,7 +93,7 @@ export class OrganizationController extends Controller {
     organizationID,
     roleID,
   }: RemoveRoleRequirementOrganizationArguments): Promise<
-    rm.IRestResponse<RoleRequirementAPIResponse>
+    SlashauthResponse<RoleRequirementAPIResponse>
   > {
     const urlParams = signQuery({
       input: {

--- a/packages/core/src/controllers/user.ts
+++ b/packages/core/src/controllers/user.ts
@@ -1,4 +1,3 @@
-import * as rm from 'typed-rest-client';
 import {
   AddAssignedRoleToUserArguments,
   AssignedRoleAPIResponse,
@@ -20,6 +19,7 @@ import {
   ValidateTokenArguments,
   ValidateTokenResponse,
 } from '@slashauth/types';
+import { WrappedClient, SlashauthResponse } from '../client';
 import { signBody, signQuery } from '../utils/query';
 import { base64Decode } from '../utils/strings';
 import { Controller } from './controller';
@@ -31,7 +31,7 @@ export class UserController extends Controller {
   constructor(
     client_id: string,
     client_secret: string,
-    apiClient: rm.RestClient
+    apiClient: WrappedClient
   ) {
     super(client_id, client_secret, apiClient);
   }
@@ -104,7 +104,7 @@ export class UserController extends Controller {
     userID,
     role,
     organizationID,
-  }: HasRoleArguments): Promise<rm.IRestResponse<HasRoleAPIResponse>> {
+  }: HasRoleArguments): Promise<SlashauthResponse<HasRoleAPIResponse>> {
     const encodedRole = Buffer.from(role, 'utf8').toString('base64');
 
     const urlParams = signQuery({
@@ -127,7 +127,7 @@ export class UserController extends Controller {
     address,
     role,
     organizationID,
-  }: HasRoleWalletArguments): Promise<rm.IRestResponse<HasRoleAPIResponse>> {
+  }: HasRoleWalletArguments): Promise<SlashauthResponse<HasRoleAPIResponse>> {
     const encodedRole = Buffer.from(role, 'utf8').toString('base64');
 
     const urlParams = signQuery({
@@ -150,7 +150,7 @@ export class UserController extends Controller {
     token,
     role,
     organizationID,
-  }: HasRoleTokenArguments): Promise<rm.IRestResponse<HasRoleAPIResponse>> {
+  }: HasRoleTokenArguments): Promise<SlashauthResponse<HasRoleAPIResponse>> {
     const encodedRole = Buffer.from(role, 'utf8').toString('base64');
 
     const urlParams = {
@@ -178,7 +178,7 @@ export class UserController extends Controller {
   async getOrgMemberships({
     userID,
   }: GetOrgMembershipsForUserArguments): Promise<
-    rm.IRestResponse<GetOrgMembershipsForUserAPIResponse>
+    SlashauthResponse<GetOrgMembershipsForUserAPIResponse>
   > {
     const urlParams = signQuery({
       input: {
@@ -200,7 +200,7 @@ export class UserController extends Controller {
   async getUserByID({
     userID,
     organizationID,
-  }: GetUserByIDArguments): Promise<rm.IRestResponse<UserResponse>> {
+  }: GetUserByIDArguments): Promise<SlashauthResponse<UserResponse>> {
     const input: { [key: string]: string } = {};
 
     if (organizationID) {
@@ -224,7 +224,7 @@ export class UserController extends Controller {
   async getUsers({
     organizationID,
     cursor,
-  }: GetUsersArguments): Promise<rm.IRestResponse<GetUsersResponse>> {
+  }: GetUsersArguments): Promise<SlashauthResponse<GetUsersResponse>> {
     const input: { [key: string]: string } = {};
 
     if (organizationID) {
@@ -254,7 +254,7 @@ export class UserController extends Controller {
     phoneNumber,
     nickname,
     metadata,
-  }: CreateUserArguments): Promise<rm.IRestResponse<UserResponse>> {
+  }: CreateUserArguments): Promise<SlashauthResponse<UserResponse>> {
     const body = signBody({
       input: {
         wallet,
@@ -276,7 +276,7 @@ export class UserController extends Controller {
     nickname,
     metadata,
     organizationID,
-  }: PutUserMetadataArguments): Promise<rm.IRestResponse<UserResponse>> {
+  }: PutUserMetadataArguments): Promise<SlashauthResponse<UserResponse>> {
     const body = signBody({
       input: {
         nickname,
@@ -295,7 +295,7 @@ export class UserController extends Controller {
     role,
     organizationID,
   }: AddAssignedRoleToUserArguments): Promise<
-    rm.IRestResponse<AssignedRoleAPIResponse>
+    SlashauthResponse<AssignedRoleAPIResponse>
   > {
     const body = signBody({
       input: {
@@ -317,7 +317,7 @@ export class UserController extends Controller {
     role,
     organizationID,
   }: RemoveAssignedRoleFromUserArguments): Promise<
-    rm.IRestResponse<AssignedRoleAPIResponse>
+    SlashauthResponse<AssignedRoleAPIResponse>
   > {
     const encodedRole = Buffer.from(role, 'utf8').toString('base64');
 

--- a/packages/express/package-lock.json
+++ b/packages/express/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/express",
-  "version": "0.1.0-beta1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/express",
-      "version": "0.1.0-beta1",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@slashauth/node-client": "^0.8.0-beta2"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/express",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,6 +29,6 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@slashauth/node-client": "^0.9.2"
+    "@slashauth/node-client": "^0.10.0"
   }
 }

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -59,12 +59,12 @@ export class SlashauthMiddlewareExpress {
     ) => {
       const authHeader = req.headers.authorization || '';
       const token = parseToken(authHeader);
-      const hasRoleResp = await this.client.user.hasRoleToken({
+      const [hasRole] = await this.client.user.hasRoleToken({
         role,
         token,
       });
 
-      if (hasRoleResp.result && hasRoleResp.result.hasRole) {
+      if (hasRole) {
         next();
         return;
       }

--- a/packages/nextjs/package-lock.json
+++ b/packages/nextjs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/nextjs",
-  "version": "0.1.0-beta1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/nextjs",
-      "version": "0.1.0-beta1",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@slashauth/node-client": "^0.8.0-beta4",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/nextjs",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@slashauth/node-client": "^0.9.2",
+    "@slashauth/node-client": "^0.10.0",
     "next": "^12.3.1"
   }
 }

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -80,13 +80,13 @@ export class SlashauthMiddlewareNext {
       const authHeader = req.headers.authorization || '';
       const token = parseToken(authHeader);
 
-      const hasRoleResp = await this.client.user.hasRoleToken({
+      const [hasRole] = await this.client.user.hasRoleToken({
         role,
         token,
       });
 
-      if (hasRoleResp.result && hasRoleResp.result.hasRole !== undefined) {
-        return hasRoleResp.result.hasRole;
+      if (hasRole) {
+        return hasRole;
       }
 
       throw new Error('hasRole did not properly return');

--- a/packages/types/package-lock.json
+++ b/packages/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/types",
-  "version": "0.1.0-beta1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/types",
-      "version": "0.1.0-beta1",
+      "version": "0.4.0",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/types",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/src/apps.ts
+++ b/packages/types/src/apps.ts
@@ -1,7 +1,9 @@
 export type GetInfoResponse = {
-  data: {
-    clientID: string;
-    name: string;
-    description?: string;
-  };
+  data: App;
+};
+
+export type App = {
+  clientID: string;
+  name: string;
+  description?: string;
 };

--- a/packages/types/src/blobs.ts
+++ b/packages/types/src/blobs.ts
@@ -12,10 +12,12 @@ export type CreateBlobUploadArguments = {
 };
 
 export type CreateBlobUploadResponse = {
-  data: {
-    id: string;
-    signedUrl: string;
-  };
+  data: CreatedBlobData;
+};
+
+export type CreatedBlobData = {
+  id: string;
+  signedUrl: string;
 };
 
 export type UpdateBlobUploadStatusArguments = {
@@ -25,8 +27,10 @@ export type UpdateBlobUploadStatusArguments = {
 };
 
 export type UpdateBlobUploadStatusResponse = {
-  data: {
-    id: string;
-    status: string;
-  };
+  data: UpdatedBlobData;
+};
+
+export type UpdatedBlobData = {
+  id: string;
+  status: string;
 };

--- a/packages/types/src/files.ts
+++ b/packages/types/src/files.ts
@@ -1,3 +1,5 @@
+import { PaginationMetadata } from './utils';
+
 export type FileRecord = {
   id: string;
   blobID: string;
@@ -23,19 +25,19 @@ export type GetPresignedURLForFileArguments = {
 
 export type GetPresignedURLForFileResponse = {
   data: {
-    url: string;
+    url: PresignedURLForFile;
   };
 };
+
+export type PresignedURLForFile = string;
 
 export type ListFilesArguments = {
   organizationID?: string;
   cursor?: string;
 };
 
-export type ListFilesResponse = {
+export type ListFilesResponse = ListFilesMetadata & {
   data: FileRecord[];
-  hasMore: boolean;
-  cursor?: string;
 };
 
 export type AddFileArguments = {
@@ -47,6 +49,8 @@ export type AddFileArguments = {
   mimeType: string;
   file: Buffer;
 };
+
+type ListFilesMetadata = PaginationMetadata;
 
 export type CreateFileArguments = {
   organizationID?: string;

--- a/packages/types/src/organizations.ts
+++ b/packages/types/src/organizations.ts
@@ -5,14 +5,14 @@ export type GetOrgMembershipsForUserArguments = {
 };
 
 export type GetOrgMembershipsForUserAPIResponse = {
-  data: [
-    {
-      clientID: string;
-      organizationID: string;
-      userID: string;
-      roles: string[];
-    }
-  ];
+  data: Membership[];
+};
+
+export type Membership = {
+  clientID: string;
+  organizationID: string;
+  userID: string;
+  roles: string[];
 };
 
 export type PostOrganizationArguments = {

--- a/packages/types/src/roles.ts
+++ b/packages/types/src/roles.ts
@@ -26,8 +26,10 @@ export type HasRoleTokenArguments = {
 };
 
 export type HasRoleAPIResponse = {
-  hasRole: boolean;
+  hasRole: HasRole;
 };
+
+export type HasRole = boolean;
 
 export type RoleRequirementAPIResponse = {
   id: string;
@@ -57,8 +59,10 @@ export type UpdateRoleRestrictedDataArguments = {
 };
 
 export type RoleRestrictedDataAPIResponse = {
-  data: ObjectMap;
+  data: RoleRestrictedData;
 };
+
+export type RoleRestrictedData = ObjectMap;
 
 export type AddAssignedRoleToUserArguments = {
   userID: string;

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -3,8 +3,10 @@ export type ValidateTokenArguments = {
 };
 
 export type ValidateTokenAPIResponse = {
-  isValid: boolean;
+  isValid: TokenValidity;
 };
+
+type TokenValidity = boolean;
 
 export type ValidateTokenResponse = {
   userID?: string;

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -1,4 +1,4 @@
-import { ObjectMap } from './utils';
+import { ObjectMap, PaginationMetadata } from './utils';
 
 export type UserRecord = {
   clientID: string;
@@ -21,11 +21,11 @@ export type GetUsersArguments = {
   cursor?: string;
 };
 
-export type GetUsersResponse = {
+export type GetUsersResponse = UsersMetadata & {
   data: UserRecord[];
-  hasMore: boolean;
-  cursor?: string;
 };
+
+type UsersMetadata = PaginationMetadata;
 
 export type CreateUserArguments = {
   wallet?: string;

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -1,3 +1,8 @@
 export type ObjectMap = {
   [key: string]: any;
 };
+
+export type PaginationMetadata = {
+  hasMore: boolean;
+  cursor?: string;
+};


### PR DESCRIPTION
## Refs

- **Issue**:  resolves [SLAS-393](https://getdebrief.atlassian.net/browse/SLAS-393)
- **Bug Report**: N/A <!-- Sentry url -->

<!--
Tasks:
- [ ] <issue number | issue url | text>
-->

## What?

Change all client methods to use SlashauthResponse type:
```
const [value, meta, err] = await slashauthClient.[method]()
```

<!-- Provide high level description of the feature implemented. Any information regarding why was it done is also useful -->

## Why?

To make extra fields such as response statusCode or error more accessible.

## Warnings (or deploy instructions) <!-- Optional -->

- Pending testing
- Pending update of docs and changelog