### PR TITLE
Fix: include pagination type in slashauth client responses and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This package provides a client to Slashauth to use from your node backend. Authorize any wallet within your app with a single API call.
 
+[Learn how to use SlashAuth in your project by reading the docs](https://docs.slashauth.com/)
+
 ## Features
 
 - 🔥 Login and token gating out of the box
@@ -60,7 +62,7 @@ slashauthClient
       clientID: r.clientID,
       address: r.address,
       expiresAt: r.expiresAt,
-    })
+    });
   })
   .catch((e) => console.error(e));
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or Yarn
 
 ## Initial steps
 
-In order to use Slashauth you must first create a Slashauth app. Create one [here](https://app.slashauth.xyz). Take note of your client ID and client secret because you'll need these in the next step.
+In order to use Slashauth you must first create a Slashauth app. Create one [here](https://app.slashauth.com). Take note of your client ID and client secret because you'll need these in the next step.
 
 ## Usage
 
@@ -36,13 +36,16 @@ const slashauthClient = new SlashauthClient(<your client id>, <your client secre
 Use the client to authorize whether a wallet has a specified role:
 
 ```ts
-slashauthClient
-  .hasRole({
-    address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-    role: 'admin',
-  })
-  .then((response) => console.log('has role? ', r.result.hasRole))
-  .catch((e) => console.error(e));
+const [hasRole, , err] = await slashauthClient.hasRole({
+  address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+  role: 'admin',
+});
+
+if (err) {
+  console.log(err);
+}
+
+console.log('has role? ', hasRole);
 ```
 
 Use the client to validate a user's token. This endpoint will return a 403 for invalid tokens:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,6 +4,8 @@
 
 This package provides a client to Slashauth to use from your node backend. Authorize any wallet within your app with a single API call.
 
+[Learn how to use SlashAuth in your project by reading the docs](https://docs.slashauth.com/)
+
 ## Features
 
 - 🔥 Login and token gating out of the box
@@ -60,7 +62,7 @@ slashauthClient
       clientID: r.clientID,
       address: r.address,
       expiresAt: r.expiresAt,
-    })
+    });
   })
   .catch((e) => console.error(e));
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,7 +23,7 @@ Or Yarn
 
 ## Initial steps
 
-In order to use Slashauth you must first create a Slashauth app. Create one [here](https://app.slashauth.xyz). Take note of your client ID and client secret because you'll need these in the next step.
+In order to use Slashauth you must first create a Slashauth app. Create one [here](https://app.slashauth.com). Take note of your client ID and client secret because you'll need these in the next step.
 
 ## Usage
 
@@ -36,13 +36,16 @@ const slashauthClient = new SlashauthClient(<your client id>, <your client secre
 Use the client to authorize whether a wallet has a specified role:
 
 ```ts
-slashauthClient
-  .hasRole({
-    address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-    role: 'admin',
-  })
-  .then((response) => console.log('has role? ', r.result.hasRole))
-  .catch((e) => console.error(e));
+const [hasRole, , err] = await slashauthClient.hasRole({
+  address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+  role: 'admin',
+});
+
+if (err) {
+  console.log(err);
+}
+
+console.log('has role? ', hasRole);
 ```
 
 Use the client to validate a user's token. This endpoint will return a 403 for invalid tokens:

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/node-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/node-client",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "ISC",
       "dependencies": {
         "@slashauth/types": "^0.1.0-beta2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/node-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -4,6 +4,7 @@ import { OrganizationController } from './controllers/organization';
 import { UserController } from './controllers/user';
 import { FileController } from './controllers/file';
 import { AppController } from './controllers/app';
+import { PaginationMetadata } from '@slashauth/types';
 
 type ResponseMeta<T> = Omit<rm.IRestResponse<T>, 'result'>;
 type ErrorMessage = any;
@@ -11,6 +12,12 @@ type ErrorMessage = any;
 export type SlashauthResponse<ResponseData> = [
   ResponseData | null,
   ResponseMeta<ResponseData>,
+  ErrorMessage | null
+];
+
+export type SlashauthResponseWithPagination<ResponseData> = [
+  ResponseData | null,
+  ResponseMeta<ResponseData> & PaginationMetadata,
   ErrorMessage | null
 ];
 

--- a/packages/core/src/controllers/file.ts
+++ b/packages/core/src/controllers/file.ts
@@ -20,7 +20,11 @@ import {
   BlobStatus,
 } from '@slashauth/types';
 import axios from 'axios';
-import { WrappedClient, SlashauthResponse } from '../client';
+import {
+  WrappedClient,
+  SlashauthResponse,
+  SlashauthResponseWithPagination,
+} from '../client';
 import { signQuery, signBody } from '../utils/query';
 import { checkBlobStatus } from '../utils/strings';
 import { getBaseURL } from '../utils/url';
@@ -104,7 +108,9 @@ export class FileController extends Controller {
   async listFiles({
     organizationID,
     cursor,
-  }: ListFilesArguments): Promise<SlashauthResponse<FileRecord[]>> {
+  }: ListFilesArguments): Promise<
+    SlashauthResponseWithPagination<FileRecord[]>
+  > {
     const input: { [key: string]: string } = {};
 
     if (organizationID) {
@@ -130,7 +136,7 @@ export class FileController extends Controller {
           transformResponse<ListFilesResponse, FileRecord[]>(
             (res) => res && res.data
           )(response)[0],
-          { ...metadata, hasMore: data?.hasMore, cursor: data?.cursor },
+          { ...metadata, hasMore: !!data?.hasMore, cursor: data?.cursor },
           err,
         ];
       });

--- a/packages/core/src/controllers/user.ts
+++ b/packages/core/src/controllers/user.ts
@@ -22,7 +22,11 @@ import {
   ValidateTokenArguments,
   ValidateTokenResponse,
 } from '@slashauth/types';
-import { WrappedClient, SlashauthResponse } from '../client';
+import {
+  WrappedClient,
+  SlashauthResponse,
+  SlashauthResponseWithPagination,
+} from '../client';
 import { signBody, signQuery } from '../utils/query';
 import { base64Decode } from '../utils/strings';
 import { Controller } from './controller';
@@ -240,7 +244,9 @@ export class UserController extends Controller {
   async getUsers({
     organizationID,
     cursor,
-  }: GetUsersArguments): Promise<SlashauthResponse<UserRecord[]>> {
+  }: GetUsersArguments): Promise<
+    SlashauthResponseWithPagination<UserRecord[]>
+  > {
     const input: { [key: string]: string } = {};
 
     if (organizationID) {
@@ -270,7 +276,7 @@ export class UserController extends Controller {
           transformResponse<GetUsersResponse, UserRecord[]>(
             (res) => res && res.data
           )(response)[0],
-          { ...metadata, hasMore: data?.hasMore, cursor: data?.cursor },
+          { ...metadata, hasMore: !!data?.hasMore, cursor: data?.cursor },
           err,
         ];
       });


### PR DESCRIPTION
## What?

- Include pagination attributes in returned type for `listFiles` and `getUsers` methods.
- Update readme

## Why?

Typescript complains when using pagination attributes.

